### PR TITLE
removed clean_up max_calls

### DIFF
--- a/workflow/populate/worker.py
+++ b/workflow/populate/worker.py
@@ -106,7 +106,7 @@ dlc_worker = DataJointWorker(
 
 dlc_worker(dlc_model_support.PreRecordingInfo, max_calls=5)
 dlc_worker(dlc_model.RecordingInfo, max_calls=5)
-dlc_worker(dlc_model_support.PreRecordingInfo.clean_up, max_calls=5)
+dlc_worker(dlc_model_support.PreRecordingInfo.clean_up)
 
 dlc_worker(dlc_model_support.PrePoseEstimation, max_calls=5)
 dlc_worker(dlc_model.PoseEstimation, max_calls=5)


### PR DESCRIPTION
I just noticed that there is warning that is coming up saying that clean_up does not support max_calls parameter... This should be removed right?